### PR TITLE
Update for FreeBSD Python

### DIFF
--- a/facedetect
+++ b/facedetect
@@ -5,8 +5,8 @@
 from __future__ import print_function
 
 import argparse
-import cv2
 import numpy as np
+import cv2
 import math
 import sys
 import os


### PR DESCRIPTION
I don't know if this is importan to other OS's, But for Freebsd numpy needs to be loaded before cv2 to avoid:

ImportError: numpy.core.multiarray failed to import
Traceback (most recent call last):
  File "./facedetect", line 8, in <module>
    import cv2
ImportError: numpy.core.multiarray failed to import